### PR TITLE
Reduce the system version requirements of CellView.swift

### DIFF
--- a/Jim/Cell/CellView.swift
+++ b/Jim/Cell/CellView.swift
@@ -204,7 +204,9 @@ class CellView: NSTableCellView {
             textView.setContentHuggingPriority(.required, for: .vertical)
         }
         
-        textView.string = text.trimmingCharacters(in: Foundation.CharacterSet.whitespacesAndNewlines).replacing(/\[\d+[\d;]*m/, with: "")
+        let string = text.trimmingCharacters(in: Foundation.CharacterSet.whitespacesAndNewlines)
+        let replacingString = string.replacingOccurrences(of: "/\\[\\d+\\\\d;]*m/", with: "", options: .regularExpression)
+        textView.string = replacingString
         outputStackView.addArrangedSubview(textView)
     }
     


### PR DESCRIPTION
It seems that change a little bit is OK.

Test passed on my M1 machine running 12.6.5 

MacOS 13.0 -> 12.4